### PR TITLE
better visibility for selected text highlighting

### DIFF
--- a/dracula.rstheme
+++ b/dracula.rstheme
@@ -48,7 +48,7 @@
 }
 
 .ace_marker-layer .ace_selection {
-  background: #464B5D80;
+  background: #bd93f980;
 }
 
 .ace_marker-layer .ace_step {

--- a/dracula.rstheme
+++ b/dracula.rstheme
@@ -65,7 +65,7 @@
 }
 
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid #464B5D80;
+  background-color: #bd93f980;
 }
 
 .ace_marker-layer .ace_foreign_line {


### PR DESCRIPTION
This is about the highlighting for additional occurrences of selected text. Right now the dark-blue border is barely visible on the dark editor background.

Edit: changed highlighting of the Find function to match
Edit2: might be wrong, but I think Github's editor automatically fixed #2

## selected text
### before
![before1](https://user-images.githubusercontent.com/29800411/139876058-8183f0df-0714-4df8-bdc8-70376180134e.png)
## after
![after1](https://user-images.githubusercontent.com/29800411/139876084-7bedb473-6cb4-4eeb-9b29-27f40e8355f5.png)

## Find & Replace
### before
![before2](https://user-images.githubusercontent.com/29800411/139923644-a3b56bac-d5a3-4f44-a939-d1b8c56fe648.png)
### after
![after2](https://user-images.githubusercontent.com/29800411/139923697-c8251d55-73df-40ba-a6db-f1d0d4858c48.png)
