### PR TITLE
change color of message/warning/error to red

### DIFF
--- a/dracula.rstheme
+++ b/dracula.rstheme
@@ -120,7 +120,7 @@
 }
 
 .ace_constant.ace_language {
-  color: #BD93F9;
+  color: #ff5555;
 }
 
 .ace_constant.ace_numeric {


### PR DESCRIPTION
Right now messages, warnings, and errors use the same color as console input. This can make it quite hard to notice them flying by when running long scripts. Fixes #5 

before
![before](https://user-images.githubusercontent.com/29800411/140054629-9e82fae7-16c5-4d3f-aa95-35c210ec2622.png)
after
![after](https://user-images.githubusercontent.com/29800411/140054628-9b1fe1f0-a8dc-4681-8100-28de7ef326d1.png)


